### PR TITLE
Swap order of JSON Decoding

### DIFF
--- a/lib/webhook-signature-verifier.rb
+++ b/lib/webhook-signature-verifier.rb
@@ -33,7 +33,8 @@ module WebhookSignatureVerifier
 
     post '/verify' do
       begin
-        payload      = request_body.fetch('payload', '')
+        json_payload      = request_body.fetch('payload', '')
+        payload = JSON.parse(json_payload)
         signature    = request.env["HTTP_SIGNATURE"]
 
         pkey = OpenSSL::PKey::RSA.new(public_key)
@@ -60,7 +61,7 @@ module WebhookSignatureVerifier
     end
 
     def request_body
-      JSON.parse(request.body.read)
+      request.body.read
     end
 
     def public_key


### PR DESCRIPTION
The POST from Travis is encoded with `application/x-www-form-urlencoded` and Sinatra correctly handles decoding this when you access `request.body.read`.  However, this decodes to one key value pair: `payload` and the JSON string of the data.  To properly decode the POST you need to extract the value of `payload` **THEN** parse that as JSON.  The existing version reverses the order of these operations, and I don't believe it will work.